### PR TITLE
Add wildcard prompt generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Project [ConquestAce](http://www.conquestace.com/)
 
+This project is built with [Astro](https://astro.build/) and contains a few experimental interfaces.
+
+## Wildcard Prompt Generator
+
+Visit `/wildcards` to upload wildcard `.txt` files and generate prompts. The selected files are parsed in the browser and sent to `/api/prompt` for processing. At the moment the server replies with a placeholder message but demonstrates how wildcard data can be collected.

--- a/src/pages/api/prompt.ts
+++ b/src/pages/api/prompt.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const { wildcards, promptType } = await request.json();
+
+    const fileCount = wildcards ? Object.keys(wildcards).length : 0;
+
+    return new Response(
+      JSON.stringify({
+        prompt: `Generated prompt for ${fileCount} wildcard file(s) using ${promptType ?? 'default'} mode.`
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ prompt: 'Error processing request.' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+};

--- a/src/pages/wildcards.astro
+++ b/src/pages/wildcards.astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Wildcard Prompt Generator">
+  <h1 class="text-2xl font-mono text-lightblue mb-4">Wildcard Prompt Generator</h1>
+  <div class="space-y-4">
+    <input id="files" type="file" accept=".txt" multiple class="text-softgray" />
+    <select id="promptType" class="bg-slatecard border border-slategray text-lightblue p-2 rounded">
+      <option value="default">Default</option>
+      <option value="advanced">Advanced</option>
+    </select>
+    <button id="generate" class="bg-mathblue text-midnight px-4 py-2 rounded">Generate Prompt</button>
+    <pre id="output" class="mt-4 p-4 bg-slatecard border border-slategray text-lightblue font-mono rounded h-40 overflow-y-auto"></pre>
+  </div>
+
+  <script>
+    if (typeof window !== 'undefined') {
+      const fileInput = document.getElementById('files');
+      const btn = document.getElementById('generate');
+      const out = document.getElementById('output');
+      const typeSelect = document.getElementById('promptType');
+
+      async function readFiles() {
+        const data = {};
+        const files = fileInput.files || [];
+        for (const file of files) {
+          const text = await file.text();
+          data[file.name.replace(/\.txt$/i, '')] = text.split(/\r?\n/).filter(l => l.trim());
+        }
+        return data;
+      }
+
+      btn?.addEventListener('click', async () => {
+        out.textContent = 'Processing...';
+        const wildcards = await readFiles();
+        const res = await fetch('/api/prompt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wildcards, promptType: typeSelect.value })
+        });
+        const data = await res.json();
+        out.textContent = data.prompt || 'No response';
+      });
+    }
+  </script>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- create `/wildcards` page to upload wildcard `.txt` files
- send parsed files to new `/api/prompt` endpoint
- return a placeholder prompt response
- document the feature

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd71739883309ff1dba5ad37ea38