### PR TITLE
Switch wildcarder to OpenAI and user-supplied keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Source ➜ [`src/pages/newtab.astro`](./src/pages/newtab.astro) + [`src/script
 
 ## TerminalOverlay
 
-A full‑screen **AI terminal interface** that responds in cryptic, hacker‑style prose.
+- A full‑screen **AI terminal interface** that responds in cryptic, hacker‑style prose.
 
-- **OpenUI Gemma‑3** primary LLM (via `/api/chat/completions`).
+- **OpenAI Chat API** primary LLM (or custom endpoint).
 - **Gemini 2 Flash** fallback after 5 s timeout.
 - **Streaming output** rendered with a faux CRT scan‑line effect, cursor blink, and occasional *ASCII corruption*.
 - Accepts site navigation commands (`help`, `goto /wildcarder`, etc.) and forwards unknown input to the LLM.
@@ -55,7 +55,7 @@ A lightweight Astro-powered tool for turning **wildcard `.txt` files** into **re
 | `PromptBuilder.astro`                 | Builds the **initial prompt** by randomly sampling lines from selected wildcards.<br>• User controls sample count per file.<br>• Supports **🔄 Re-roll**, manual editing, and live broadcasting via `initial-prompt`.                                                                                                                                                                                                                                                                                                                     |
 | `LLMControls.astro`                   | Sends prompt + instructions to the backend:<br>• Optional **extra instructions** textarea.<br>• Choose from **system prompt presets** (`danbooru`, `natural-language`, future).<br>• POSTs everything to `/.netlify/functions/generatePrompt`.                                                                                                                                                                                                                                                                                             |
 | `PromptSaver.astro`                  | Local prompt memory:<br>• Save most recent LLM output 📌<br>• View full list 📜<br>• Download all as `prompts.txt` ⬇️<br>• Clear saved prompts 🗑️<br>• Button state updates automatically based on interaction.<br>• No backend; all browser-local.                                                                                                                                                                                                                                                   |
-| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends clean prompts to **Gemma-3 via OpenUI**<br>• Auto-fallback to **Gemini 2 Flash** if Gemma fails.                                                                                                                                                       |
+| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends prompts to **OpenAI Chat API** or your custom endpoint<br>• Auto-fallback to **Gemini 2 Flash** if the primary call fails.                                                                                                                                                       |
 
 ---
 
@@ -108,7 +108,8 @@ Supports:
 
   * Runs **OpenAI Moderation API**
   * Checks per-category **probability scores** via `BLOCK_THRESHOLDS`
-  * Sends safe prompt to **Gemma-3 (OpenUI)** or **Gemini 2 Flash** fallback
+  * Sends prompts to **OpenAI Chat API** (or your custom endpoint)
+  * Falls back to **Gemini 2 Flash** if the primary call fails
 
 ---
 
@@ -150,16 +151,17 @@ netlify dev
 
 Set the following environment variables in `.env` or Netlify:
 
-* `OUI_API_KEY` — for Gemma 3 (OpenUI)
-* `GEMINI_API_KEY` — for Gemini fallback
-* `OPENAI_API_KEY` — for moderation scoring
+* `OPENAI_API_KEY` — used if no key is supplied from the browser
+
+Wildcarder now requires users to provide their **Gemini API key** in the UI. You
+may optionally supply a custom LLM endpoint and API key to use instead of the default OpenAI service.
 
 ---
 
 ## 🤝 Credits
 
 * Wildcard dataset: [ConquestAce/wildcards](https://huggingface.co/datasets/ConquestAce/wildcards)
-* OpenUI Gemma-3: `gemma3:1b-it-fp16`
+* OpenAI Chat API
 * Google Gemini 2 Flash fallback
 * Moderation via OpenAI `/moderations` endpoint
 

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -1,9 +1,11 @@
 export async function handler(event) {
   try {
-    const input = JSON.parse(event.body).input;
-    const apiKey = process.env.GEMINI_API_KEY;
+    const { input, geminiKey } = JSON.parse(event.body);
+    if (!geminiKey) {
+      return { statusCode: 400, body: JSON.stringify({ text: 'geminiKey required.' }) };
+    }
 
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiKey}`;
 
     const response = await fetch(url, {
       method: "POST",

--- a/netlify/functions/gpugarden.js
+++ b/netlify/functions/gpugarden.js
@@ -2,17 +2,16 @@ import fetch from "node-fetch";
 
 export async function handler(event) {
   try {
-    const input = JSON.parse(event.body).input;
-    const token = process.env.DEEPSEEK_API_KEY;
+    const { input, openaiKey, llmUrl } = JSON.parse(event.body);
 
-    const url = 'https://oui.gpu.garden/api/chat/completions';
+    const url = llmUrl || 'https://api.openai.com/v1/chat/completions';
     const headers = {
-      'Authorization': `Bearer ${token}`,
+      'Authorization': `Bearer ${openaiKey || process.env.OPENAI_API_KEY}`,
       'Content-Type': 'application/json',
     };
 
     const data = {
-      model: 'gemma3:1b-it-fp16',
+      model: 'gpt-3.5-turbo',
       messages: [
         {
           role: 'system',

--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -18,6 +18,23 @@
     </select>
   </label>
 
+  <!-- user keys / endpoints -->
+  <label class="font-medium text-white">Gemini API Key
+    <input id="geminiKey" type="password"
+           class="bg-slatecard p-1 rounded ml-2 w-full"
+           placeholder="required" />
+  </label>
+  <label class="font-medium text-white">OpenAI / Local API Key
+    <input id="openaiKey" type="password"
+           class="bg-slatecard p-1 rounded ml-2 w-full"
+           placeholder="defaults to server" />
+  </label>
+  <label class="font-medium text-white">Custom LLM URL
+    <input id="llmUrl" type="text"
+           class="bg-slatecard p-1 rounded ml-2 w-full"
+           placeholder="https://api.openai.com/v1/chat/completions" />
+  </label>
+
   <!-- send -->
   <button id="send-btn"
           class="bg-green-700 text-white px-3 py-2 rounded disabled:opacity-40"
@@ -28,17 +45,25 @@
 
 <script is:client>
   /* element refs */
-  const btn   = document.getElementById('send-btn');
-  const notes = document.getElementById('llm-notes');
+  const btn       = document.getElementById('send-btn');
+  const notes     = document.getElementById('llm-notes');
   const presetSel = document.getElementById('llmPreset');
+  const gemKey    = document.getElementById('geminiKey');
+  const openaiKey = document.getElementById('openaiKey');
+  const llmUrl    = document.getElementById('llmUrl');
 
   let initialPrompt = '';
 
   /* get initial prompt from PromptBuilder */
+  function updateBtn() {
+    btn.disabled = !(initialPrompt && gemKey.value.trim());
+  }
+
   window.addEventListener('initial-prompt', e => {
     initialPrompt = e.detail.trim();
-    btn.disabled = !initialPrompt;
+    updateBtn();
   });
+  gemKey.addEventListener('input', updateBtn);
 
   /* click → POST to Netlify function */
   btn.addEventListener('click', async () => {
@@ -52,8 +77,11 @@
         headers: { 'Content-Type': 'application/json' },
         body   : JSON.stringify({
           initialPrompt,
-          preset: presetSel.value,          // <── chosen preset
-          instructions: notes.value.trim()  // <── extra textarea
+          preset       : presetSel.value,          // <── chosen preset
+          instructions : notes.value.trim(),       // <── extra textarea
+          geminiKey    : gemKey.value.trim(),
+          openaiKey    : openaiKey.value.trim(),
+          llmUrl       : llmUrl.value.trim()
         })
       });
 

--- a/src/components/TerminalOverlay.astro
+++ b/src/components/TerminalOverlay.astro
@@ -17,6 +17,12 @@
       <!-- Chat will be restored here -->
     </div>
 
+    <div class="space-y-2 mb-2">
+      <input id="geminiKeyTerm" type="password" class="w-full bg-slatecard p-1 rounded" placeholder="Gemini API Key" />
+      <input id="openaiKeyTerm" type="password" class="w-full bg-slatecard p-1 rounded" placeholder="OpenAI / Local API Key" />
+      <input id="llmUrlTerm" type="text" class="w-full bg-slatecard p-1 rounded" placeholder="Custom LLM URL" />
+    </div>
+
     <form id="console-form" class="flex gap-2">
       <span class="text-sky">hacker@conquestace.com</span>:~$
       <input
@@ -91,6 +97,9 @@
     const form = document.getElementById('console-form');
     const input = document.getElementById('console-input');
     const log = document.getElementById('console-log');
+    const gemKey = document.getElementById('geminiKeyTerm');
+    const openaiKey = document.getElementById('openaiKeyTerm');
+    const llmUrl = document.getElementById('llmUrlTerm');
 
     if (shouldClearHistory()) clearHistory();
     renderHistory(log);
@@ -131,7 +140,12 @@
         const response = await fetch("/.netlify/functions/llm-router", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ messages })
+          body: JSON.stringify({
+            messages,
+            geminiKey: gemKey.value.trim(),
+            openaiKey: openaiKey.value.trim(),
+            llmUrl: llmUrl.value.trim()
+          })
         });
 
         const data = await response.json();


### PR DESCRIPTION
## Summary
- require Gemini API key input in Wildcarder UI
- allow specifying OpenAI/local API key and custom LLM URL
- replace gpu.garden calls with OpenAI API in Netlify functions
- update TerminalOverlay to pass user keys
- document new setup in README

## Testing
- `npm run build` *(fails: astro not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68513413c100833088126e4cd2c6c4c7