### PR TITLE
Switch to OpenAI for LLM and require Gemini key input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Source ➜ [`src/pages/newtab.astro`](./src/pages/newtab.astro) + [`src/script
 
 ## TerminalOverlay
 
-A full‑screen **AI terminal interface** that responds in cryptic, hacker‑style prose.
+- A full‑screen **AI terminal interface** that responds in cryptic, hacker‑style prose.
 
-- **OpenUI Gemma‑3** primary LLM (via `/api/chat/completions`).
+- **OpenAI Chat Completions** primary LLM (endpoint configurable via `OPENAI_BASE_URL`).
 - **Gemini 2 Flash** fallback after 5 s timeout.
 - **Streaming output** rendered with a faux CRT scan‑line effect, cursor blink, and occasional *ASCII corruption*.
 - Accepts site navigation commands (`help`, `goto /wildcarder`, etc.) and forwards unknown input to the LLM.
@@ -55,7 +55,7 @@ A lightweight Astro-powered tool for turning **wildcard `.txt` files** into **re
 | `PromptBuilder.astro`                 | Builds the **initial prompt** by randomly sampling lines from selected wildcards.<br>• User controls sample count per file.<br>• Supports **🔄 Re-roll**, manual editing, and live broadcasting via `initial-prompt`.                                                                                                                                                                                                                                                                                                                     |
 | `LLMControls.astro`                   | Sends prompt + instructions to the backend:<br>• Optional **extra instructions** textarea.<br>• Choose from **system prompt presets** (`danbooru`, `natural-language`, future).<br>• POSTs everything to `/.netlify/functions/generatePrompt`.                                                                                                                                                                                                                                                                                             |
 | `PromptSaver.astro`                  | Local prompt memory:<br>• Save most recent LLM output 📌<br>• View full list 📜<br>• Download all as `prompts.txt` ⬇️<br>• Clear saved prompts 🗑️<br>• Button state updates automatically based on interaction.<br>• No backend; all browser-local.                                                                                                                                                                                                                                                   |
-| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends clean prompts to **Gemma-3 via OpenUI**<br>• Auto-fallback to **Gemini 2 Flash** if Gemma fails.                                                                                                                                                       |
+| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends clean prompts to **OpenAI Chat Completions (configurable)**<br>• Auto-fallback to **Gemini 2 Flash** if OpenAI fails.                                                                                                                                                       |
 
 ---
 
@@ -108,7 +108,7 @@ Supports:
 
   * Runs **OpenAI Moderation API**
   * Checks per-category **probability scores** via `BLOCK_THRESHOLDS`
-  * Sends safe prompt to **Gemma-3 (OpenUI)** or **Gemini 2 Flash** fallback
+  * Sends safe prompt to **OpenAI Chat Completions** (or your local endpoint) with **Gemini 2 Flash** as fallback
 
 ---
 
@@ -150,16 +150,17 @@ netlify dev
 
 Set the following environment variables in `.env` or Netlify:
 
-* `OUI_API_KEY` — for Gemma 3 (OpenUI)
-* `GEMINI_API_KEY` — for Gemini fallback
-* `OPENAI_API_KEY` — for moderation scoring
+* `OPENAI_API_KEY` — used for moderation and as the default Chat Completion key
+* `OPENAI_BASE_URL` — optional custom endpoint for local LLMs
+
+The Gemini API key is now entered in the Wildcarder UI when sending a request.
 
 ---
 
 ## 🤝 Credits
 
 * Wildcard dataset: [ConquestAce/wildcards](https://huggingface.co/datasets/ConquestAce/wildcards)
-* OpenUI Gemma-3: `gemma3:1b-it-fp16`
+* OpenAI Chat Completions (GPT-3.5/4)
 * Google Gemini 2 Flash fallback
 * Moderation via OpenAI `/moderations` endpoint
 

--- a/netlify/functions/generatePrompt.js
+++ b/netlify/functions/generatePrompt.js
@@ -69,8 +69,16 @@ export const handler = async (event) => {
   try { body = JSON.parse(event.body || '{}'); }
   catch { return bad('Invalid JSON payload.'); }
 
-  const { initialPrompt, preset = 'default', instructions = '' } = body;
+  const {
+    initialPrompt,
+    preset = 'default',
+    instructions = '',
+    llmBase,
+    llmKey,
+    geminiKey
+  } = body;
   if (!initialPrompt?.trim()) return bad('initialPrompt missing.');
+  if (!geminiKey) return bad('geminiKey required.');
 
   /* 2 ─ content-policy gate ------------------------------------------- */
   const combinedInput = `${initialPrompt}\n\n${instructions}`;
@@ -89,41 +97,41 @@ export const handler = async (event) => {
     { role: 'user',   content: initialPrompt }
   ];
 
-  /* 4 ─ OpenUI (Gemma-3 primary) -------------------------------------- */
+  /* 4 ─ OpenAI (primary) ---------------------------------------------- */
   try {
-    const ouiRes = await fetch(
-      'https://oui.gpu.garden/api/chat/completions',
-      {
-        method : 'POST',
-        headers: {
-          Authorization : `Bearer ${process.env.OUI_API_KEY}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          model: 'gemma3:1b-it-fp16',
-          messages,
-          max_tokens: 1024
-        }),
-        signal: AbortSignal.timeout?.(30_000)
-      }
-    );
+    const base = llmBase || process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+    const key  = llmKey  || process.env.OPENAI_API_KEY;
 
-    if (ouiRes.ok) {
-      const data = await ouiRes.json();
+    const aiRes = await fetch(`${base.replace(/\/$/, '')}/chat/completions`, {
+      method : 'POST',
+      headers: {
+        Authorization : `Bearer ${key}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages,
+        max_tokens: 1024
+      }),
+      signal: AbortSignal.timeout?.(30_000)
+    });
+
+    if (aiRes.ok) {
+      const data = await aiRes.json();
       const txt  = data?.choices?.[0]?.message?.content?.trim();
       if (txt) return ok(txt);
     } else {
-      console.warn('[OpenUI] HTTP', ouiRes.status);
+      console.warn('[OpenAI] HTTP', aiRes.status);
     }
   } catch (err) {
-    console.warn('[OpenUI error]', err.message);
+    console.warn('[OpenAI error]', err.message);
   }
 
   /* 5 ─ Gemini-Flash fallback ----------------------------------------- */
   try {
     const url =
       'https://generativelanguage.googleapis.com/v1beta/models/' +
-      'gemini-2.0-flash:generateContent?key=' + process.env.GEMINI_API_KEY;
+      'gemini-2.0-flash:generateContent?key=' + geminiKey;
 
     const gRes = await fetch(url, {
       method : 'POST',

--- a/netlify/functions/gpugarden.js
+++ b/netlify/functions/gpugarden.js
@@ -3,16 +3,17 @@ import fetch from "node-fetch";
 export async function handler(event) {
   try {
     const input = JSON.parse(event.body).input;
-    const token = process.env.DEEPSEEK_API_KEY;
+    const token = process.env.OPENAI_API_KEY;
+    const base  = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 
-    const url = 'https://oui.gpu.garden/api/chat/completions';
+    const url = `${base.replace(/\/$/, '')}/chat/completions`;
     const headers = {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',
     };
 
     const data = {
-      model: 'gemma3:1b-it-fp16',
+      model: 'gpt-3.5-turbo',
       messages: [
         {
           role: 'system',
@@ -40,7 +41,7 @@ export async function handler(event) {
       body: JSON.stringify({ text: output })
     };
   } catch (err) {
-    console.error("DeepSeek handler error:", err);
+    console.error("OpenAI handler error:", err);
     return {
       statusCode: 500,
       body: JSON.stringify({ text: "Error: " + err.message })

--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -8,6 +8,12 @@
   <textarea id="llm-notes" rows="3"
             class="w-full bg-slatecard p-2 rounded resize-y font-mono"></textarea>
 
+  <!-- gemini api key -->
+  <label class="font-medium text-white">
+    Gemini API key
+    <input id="gemini-key" type="password" class="bg-slatecard p-1 rounded ml-2" />
+  </label>
+
   <!-- preset selector -->
   <label class="font-medium text-white">
     System-prompt preset
@@ -28,9 +34,15 @@
 
 <script is:client>
   /* element refs */
-  const btn   = document.getElementById('send-btn');
-  const notes = document.getElementById('llm-notes');
+  const btn       = document.getElementById('send-btn');
+  const notes     = document.getElementById('llm-notes');
   const presetSel = document.getElementById('llmPreset');
+  const gemKeyInp = document.getElementById('gemini-key');
+
+  gemKeyInp.value = localStorage.getItem('geminiKey') || '';
+  gemKeyInp.addEventListener('input', () => {
+    localStorage.setItem('geminiKey', gemKeyInp.value.trim());
+  });
 
   let initialPrompt = '';
 
@@ -53,7 +65,8 @@
         body   : JSON.stringify({
           initialPrompt,
           preset: presetSel.value,          // <── chosen preset
-          instructions: notes.value.trim()  // <── extra textarea
+          instructions: notes.value.trim(), // <── extra textarea
+          geminiKey: gemKeyInp.value.trim()
         })
       });
 


### PR DESCRIPTION
## Summary
- ask for user's Gemini API key in Wildcarder UI
- default to OpenAI Chat Completions for prompt generation
- allow overriding OpenAI base URL for local LLMs
- update llm router and gpugarden functions to use OpenAI
- refresh README to reflect new defaults

## Testing
- `npm run build` *(fails: astro not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68513413c100833088126e4cd2c6c4c7