### PR TITLE
Add user-configurable LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Source ➜ [`src/pages/newtab.astro`](./src/pages/newtab.astro) + [`src/script
 
 A full‑screen **AI terminal interface** that responds in cryptic, hacker‑style prose.
 
-- **OpenUI Gemma‑3** primary LLM (via `/api/chat/completions`).
+- **OpenAI** (or local) primary LLM via `/chat/completions`.
 - **Gemini 2 Flash** fallback after 5 s timeout.
 - **Streaming output** rendered with a faux CRT scan‑line effect, cursor blink, and occasional *ASCII corruption*.
 - Accepts site navigation commands (`help`, `goto /wildcarder`, etc.) and forwards unknown input to the LLM.
@@ -52,10 +52,11 @@ A lightweight Astro-powered tool for turning **wildcard `.txt` files** into **re
 | Module                                | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `WildcardLoader.astro`                | *Client-only island* for loading `.txt` wildcard files:<br>• **Drag & drop** or **browse** files manually.<br>• **Load defaults** from Hugging Face (`danbooru`, `natural-language`).<br>• **Multi-level cherry-picking**:<br>  1️⃣ **Collection selector** (top-level)<br>  2️⃣ **Category pills** (e.g., `clothing`, `styles`)<br>  3️⃣ **File pills** (wrap + multi-select)<br>• Can load **entire categories** *or* only selected files.<br>• Auto-wraps file pills to new lines.<br>• Remove files individually 🗑️ or **clear all** 🧹.<br>• Emits `wildcards-loaded` with full `{ [filename]: lines[] }` structure. |
+| `LLMConfigurator.astro`               | Button to pick **Gemini**, **OpenAI**, or **Local** provider and set the model name. Saved in `localStorage`. |
 | `PromptBuilder.astro`                 | Builds the **initial prompt** by randomly sampling lines from selected wildcards.<br>• User controls sample count per file.<br>• Supports **🔄 Re-roll**, manual editing, and live broadcasting via `initial-prompt`.                                                                                                                                                                                                                                                                                                                     |
-| `LLMControls.astro`                   | Sends prompt + instructions to the backend:<br>• Optional **extra instructions** textarea.<br>• Choose from **system prompt presets** (`danbooru`, `natural-language`, future).<br>• POSTs everything to `/.netlify/functions/generatePrompt`.                                                                                                                                                                                                                                                                                             |
+| `LLMControls.astro`                   | Sends prompt + instructions to the backend:<br>• Optional **extra instructions** textarea.<br>• Choose from **system prompt presets** (`danbooru`, `natural-language`, future).<br>• POSTs everything to `/.netlify/functions/generatePrompt`.<br>• Requires your own Gemini API key                                                                                                                                                                                                                                                                                             |
 | `PromptSaver.astro`                  | Local prompt memory:<br>• Save most recent LLM output 📌<br>• View full list 📜<br>• Download all as `prompts.txt` ⬇️<br>• Clear saved prompts 🗑️<br>• Button state updates automatically based on interaction.<br>• No backend; all browser-local.                                                                                                                                                                                                                                                   |
-| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends clean prompts to **Gemma-3 via OpenUI**<br>• Auto-fallback to **Gemini 2 Flash** if Gemma fails.                                                                                                                                                       |
+| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends prompts to **OpenAI** or a custom `LOCAL_LLM_URL`<br>• Auto-fallback to **Gemini 2 Flash** if primary LLM fails.                                                                                                                                                       |
 
 ---
 
@@ -108,7 +109,7 @@ Supports:
 
   * Runs **OpenAI Moderation API**
   * Checks per-category **probability scores** via `BLOCK_THRESHOLDS`
-  * Sends safe prompt to **Gemma-3 (OpenUI)** or **Gemini 2 Flash** fallback
+  * Sends safe prompt to **OpenAI** (or custom LLM) with **Gemini 2 Flash** fallback
 
 ---
 
@@ -150,16 +151,17 @@ netlify dev
 
 Set the following environment variables in `.env` or Netlify:
 
-* `OUI_API_KEY` — for Gemma 3 (OpenUI)
-* `GEMINI_API_KEY` — for Gemini fallback
-* `OPENAI_API_KEY` — for moderation scoring
+* `OPENAI_API_KEY` — for OpenAI calls and moderation
+* `LOCAL_LLM_URL`  — optional custom LLM endpoint
+* `LOCAL_LLM_KEY`  — auth token for the custom endpoint
+* `GEMINI_API_KEY` — for Gemini fallback in TerminalOverlay
 
 ---
 
 ## 🤝 Credits
 
 * Wildcard dataset: [ConquestAce/wildcards](https://huggingface.co/datasets/ConquestAce/wildcards)
-* OpenUI Gemma-3: `gemma3:1b-it-fp16`
+* OpenAI GPT models
 * Google Gemini 2 Flash fallback
 * Moderation via OpenAI `/moderations` endpoint
 

--- a/netlify/functions/generatePrompt.js
+++ b/netlify/functions/generatePrompt.js
@@ -69,8 +69,16 @@ export const handler = async (event) => {
   try { body = JSON.parse(event.body || '{}'); }
   catch { return bad('Invalid JSON payload.'); }
 
-  const { initialPrompt, preset = 'default', instructions = '' } = body;
+  const {
+    initialPrompt,
+    preset = 'default',
+    instructions = '',
+    geminiKey,
+    provider = 'openai',
+    model
+  } = body;
   if (!initialPrompt?.trim()) return bad('initialPrompt missing.');
+  if (!geminiKey?.trim()) return bad('geminiKey missing.');
 
   /* 2 ─ content-policy gate ------------------------------------------- */
   const combinedInput = `${initialPrompt}\n\n${instructions}`;
@@ -89,64 +97,102 @@ export const handler = async (event) => {
     { role: 'user',   content: initialPrompt }
   ];
 
-  /* 4 ─ OpenUI (Gemma-3 primary) -------------------------------------- */
-  try {
-    const ouiRes = await fetch(
-      'https://oui.gpu.garden/api/chat/completions',
-      {
+  /* 4 ─ LLM selection ------------------------------------------------- */
+  if (provider === 'gemini') {
+    try {
+      const mdl = model || 'gemini-2.0-flash';
+      const url =
+        'https://generativelanguage.googleapis.com/v1beta/models/' +
+        `${mdl}:generateContent?key=${geminiKey}`;
+
+      const gRes = await fetch(url, {
+        method : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body   : JSON.stringify({
+          systemInstruction: { parts: [{ text: systemPrompt }] },
+          contents: [ { parts: [{ text: initialPrompt.trim() }] } ],
+          generationConfig: { maxOutputTokens: 512 }
+        })
+      });
+
+      if (!gRes.ok) {
+        const errTxt = await gRes.text().catch(() => '');
+        return fail(`Gemini HTTP ${gRes.status}: ${errTxt.slice(0,200)}`);
+      }
+
+      const data = await gRes.json();
+      const txt  = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+      if (txt) return ok(txt);
+
+      const reason = data?.promptFeedback?.blockReason || 'unknown';
+      return fail(`Gemini produced no text – block reason: ${reason}`);
+    } catch (err) {
+      return fail('Gemini request failed: ' + err.message);
+    }
+  } else {
+    try {
+      const useLocal = provider === 'local';
+      const url = useLocal
+        ? process.env.LOCAL_LLM_URL
+        : 'https://api.openai.com/v1/chat/completions';
+      const apiKey = useLocal
+        ? process.env.LOCAL_LLM_KEY
+        : process.env.OPENAI_API_KEY;
+
+      const aiRes = await fetch(url, {
         method : 'POST',
         headers: {
-          Authorization : `Bearer ${process.env.OUI_API_KEY}`,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
         },
         body: JSON.stringify({
-          model: 'gemma3:1b-it-fp16',
+          model: model || process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
           messages,
           max_tokens: 1024
         }),
         signal: AbortSignal.timeout?.(30_000)
+      });
+
+      if (aiRes.ok) {
+        const data = await aiRes.json();
+        const txt  = data?.choices?.[0]?.message?.content?.trim();
+        if (txt) return ok(txt);
+      } else {
+        console.warn('[OpenAI/local] HTTP', aiRes.status);
       }
-    );
+    } catch (err) {
+      console.warn('[OpenAI/local error]', err.message);
+    }
 
-    if (ouiRes.ok) {
-      const data = await ouiRes.json();
-      const txt  = data?.choices?.[0]?.message?.content?.trim();
+    /* fallback to Gemini */
+    try {
+      const url =
+        'https://generativelanguage.googleapis.com/v1beta/models/' +
+        'gemini-2.0-flash:generateContent?key=' + geminiKey;
+
+      const gRes = await fetch(url, {
+        method : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body   : JSON.stringify({
+          systemInstruction: { parts: [{ text: systemPrompt }] },
+          contents: [ { parts: [{ text: initialPrompt.trim() }] } ],
+          generationConfig: { maxOutputTokens: 512 }
+        })
+      });
+
+      if (!gRes.ok) {
+        const errTxt = await gRes.text().catch(() => '');
+        return fail(`Gemini HTTP ${gRes.status}: ${errTxt.slice(0,200)}`);
+      }
+
+      const data = await gRes.json();
+      const txt  = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
       if (txt) return ok(txt);
-    } else {
-      console.warn('[OpenUI] HTTP', ouiRes.status);
+
+      const reason = data?.promptFeedback?.blockReason || 'unknown';
+      return fail(`Gemini produced no text – block reason: ${reason}`);
+    } catch (err) {
+      return fail('Gemini request failed: ' + err.message);
     }
-  } catch (err) {
-    console.warn('[OpenUI error]', err.message);
-  }
-
-  /* 5 ─ Gemini-Flash fallback ----------------------------------------- */
-  try {
-    const url =
-      'https://generativelanguage.googleapis.com/v1beta/models/' +
-      'gemini-2.0-flash:generateContent?key=' + process.env.GEMINI_API_KEY;
-
-    const gRes = await fetch(url, {
-      method : 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body   : JSON.stringify({
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        contents: [ { parts: [{ text: initialPrompt.trim() }] } ],
-        generationConfig: { maxOutputTokens: 512 }
-      })
-    });
-
-    if (!gRes.ok) {
-      const errTxt = await gRes.text().catch(() => '');
-      return fail(`Gemini HTTP ${gRes.status}: ${errTxt.slice(0,200)}`);
-    }
-
-    const data = await gRes.json();
-    const txt  = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
-    if (txt) return ok(txt);
-
-    const reason = data?.promptFeedback?.blockReason || 'unknown';
-    return fail(`Gemini produced no text – block reason: ${reason}`);
-  } catch (err) {
-    return fail('Gemini request failed: ' + err.message);
   }
 };

--- a/src/components/LLMConfigurator.astro
+++ b/src/components/LLMConfigurator.astro
@@ -1,0 +1,49 @@
+---
+/* components/LLMConfigurator.astro */
+---
+<div class="mb-4 flex justify-end" data-llm-config>
+  <button id="configToggle" class="bg-slatecard text-lightblue px-2 py-1 rounded">⚙ LLM Config</button>
+</div>
+<div id="configPanel" class="hidden mb-4 bg-slatecard p-4 rounded space-y-2 text-sm text-white">
+  <label>
+    Provider
+    <select id="providerSelect" class="bg-midnight text-white ml-2 p-1 rounded">
+      <option value="openai">OpenAI</option>
+      <option value="gemini">Gemini</option>
+      <option value="local">Local</option>
+    </select>
+  </label>
+  <label>
+    Model
+    <input id="modelInput" class="bg-midnight text-white ml-2 p-1 rounded w-48" />
+  </label>
+</div>
+<script is:client>
+  const toggle = document.getElementById('configToggle');
+  const panel = document.getElementById('configPanel');
+  const provSel = document.getElementById('providerSelect');
+  const modelInp = document.getElementById('modelInput');
+
+  function load() {
+    provSel.value = localStorage.getItem('llmProvider') || 'openai';
+    modelInp.value = localStorage.getItem('llmModel') || (provSel.value === 'openai' ? 'gpt-3.5-turbo' : provSel.value === 'gemini' ? 'gemini-2.0-flash' : '');
+  }
+
+  function save() {
+    localStorage.setItem('llmProvider', provSel.value);
+    localStorage.setItem('llmModel', modelInp.value.trim());
+    window.dispatchEvent(new Event('llm-config-changed'));
+  }
+
+  toggle.addEventListener('click', () => {
+    panel.classList.toggle('hidden');
+    if (!panel.classList.contains('hidden')) {
+      load();
+    }
+  });
+
+  provSel.addEventListener('change', save);
+  modelInp.addEventListener('input', save);
+
+  load();
+</script>

--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -18,6 +18,14 @@
     </select>
   </label>
 
+  <!-- Gemini API key -->
+  <label class="font-medium text-white">
+    Gemini API Key
+    <input id="geminiKey" type="password"
+           class="bg-slatecard p-1 rounded ml-2 w-full sm:w-auto"
+           placeholder="AIza..." />
+  </label>
+
   <!-- send -->
   <button id="send-btn"
           class="bg-green-700 text-white px-3 py-2 rounded disabled:opacity-40"
@@ -31,18 +39,32 @@
   const btn   = document.getElementById('send-btn');
   const notes = document.getElementById('llm-notes');
   const presetSel = document.getElementById('llmPreset');
+  const gemKey = document.getElementById('geminiKey');
+  let provider = localStorage.getItem('llmProvider') || 'openai';
+  let model = localStorage.getItem('llmModel') || (provider === 'openai' ? 'gpt-3.5-turbo' : provider === 'gemini' ? 'gemini-2.0-flash' : '');
+
+  window.addEventListener('llm-config-changed', () => {
+    provider = localStorage.getItem('llmProvider') || 'openai';
+    model = localStorage.getItem('llmModel') || model;
+  });
+
+  function update() {
+    btn.disabled = !initialPrompt || !gemKey.value.trim();
+  }
 
   let initialPrompt = '';
 
   /* get initial prompt from PromptBuilder */
   window.addEventListener('initial-prompt', e => {
     initialPrompt = e.detail.trim();
-    btn.disabled = !initialPrompt;
+    update();
   });
+  gemKey.addEventListener('input', update);
+  window.addEventListener('llm-config-changed', update);
 
   /* click → POST to Netlify function */
   btn.addEventListener('click', async () => {
-    if (!initialPrompt) return;
+    if (!initialPrompt || !gemKey.value.trim()) return;
     btn.disabled = true;
     post('🚀 Sending to LLM…');
 
@@ -53,7 +75,10 @@
         body   : JSON.stringify({
           initialPrompt,
           preset: presetSel.value,          // <── chosen preset
-          instructions: notes.value.trim()  // <── extra textarea
+          instructions: notes.value.trim(), // <── extra textarea
+          geminiKey: gemKey.value.trim(),
+          provider,
+          model
         })
       });
 

--- a/src/pages/wildcarder.astro
+++ b/src/pages/wildcarder.astro
@@ -1,14 +1,18 @@
 ---
 import BaseLayout     from '../layouts/BaseLayout.astro';
-import WildcardLoader from '../components/WildcardLoader.astro';
-import PromptBuilder  from '../components/PromptBuilder.astro';
-import LLMControls    from '../components/LLMControls.astro';
-import TerminalOutput from '../components/TerminalOutput.astro';
-import PromptSaver    from '../components/PromptSaver.astro';
+import WildcardLoader   from '../components/WildcardLoader.astro';
+import PromptBuilder    from '../components/PromptBuilder.astro';
+import LLMControls      from '../components/LLMControls.astro';
+import LLMConfigurator  from '../components/LLMConfigurator.astro';
+import TerminalOutput   from '../components/TerminalOutput.astro';
+import PromptSaver      from '../components/PromptSaver.astro';
 ---
 
 <BaseLayout title="Wildcard Prompt Generator">
   <div class="p-6 max-w-3xl mx-auto font-mono space-y-8">
+
+    <!-- LLM configuration button -->
+    <LLMConfigurator />
 
     <!-- 1. defaults + drag-drop -->
     <WildcardLoader />


### PR DESCRIPTION
## Summary
- add new LLMConfigurator component for selecting provider/model
- hook LLMControls and generatePrompt.js to use selected provider
- expose config button on wildcarder page
- document the new configuration option

## Testing
- `npm run build` *(fails: astro not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68513413c100833088126e4cd2c6c4c7