### PR TITLE
Add user LLM configuration modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Source ➜ [`src/pages/newtab.astro`](./src/pages/newtab.astro) + [`src/script
 
 A full‑screen **AI terminal interface** that responds in cryptic, hacker‑style prose.
 
-- **OpenUI Gemma‑3** primary LLM (via `/api/chat/completions`).
+- **OpenAI** (or local) primary LLM via `/chat/completions`.
 - **Gemini 2 Flash** fallback after 5 s timeout.
 - **Streaming output** rendered with a faux CRT scan‑line effect, cursor blink, and occasional *ASCII corruption*.
 - Accepts site navigation commands (`help`, `goto /wildcarder`, etc.) and forwards unknown input to the LLM.
@@ -53,9 +53,10 @@ A lightweight Astro-powered tool for turning **wildcard `.txt` files** into **re
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `WildcardLoader.astro`                | *Client-only island* for loading `.txt` wildcard files:<br>• **Drag & drop** or **browse** files manually.<br>• **Load defaults** from Hugging Face (`danbooru`, `natural-language`).<br>• **Multi-level cherry-picking**:<br>  1️⃣ **Collection selector** (top-level)<br>  2️⃣ **Category pills** (e.g., `clothing`, `styles`)<br>  3️⃣ **File pills** (wrap + multi-select)<br>• Can load **entire categories** *or* only selected files.<br>• Auto-wraps file pills to new lines.<br>• Remove files individually 🗑️ or **clear all** 🧹.<br>• Emits `wildcards-loaded` with full `{ [filename]: lines[] }` structure. |
 | `PromptBuilder.astro`                 | Builds the **initial prompt** by randomly sampling lines from selected wildcards.<br>• User controls sample count per file.<br>• Supports **🔄 Re-roll**, manual editing, and live broadcasting via `initial-prompt`.                                                                                                                                                                                                                                                                                                                     |
-| `LLMControls.astro`                   | Sends prompt + instructions to the backend:<br>• Optional **extra instructions** textarea.<br>• Choose from **system prompt presets** (`danbooru`, `natural-language`, future).<br>• POSTs everything to `/.netlify/functions/generatePrompt`.                                                                                                                                                                                                                                                                                             |
+| `LLMConfig.astro`                     | Button to configure your LLM choice (**OpenAI**, **Gemini**, or **Local**).<br>• Lets you set model name, keys, and endpoint.<br>• Can store an **OpenAI API key** and custom **system prompt**.<br>• Saved in `localStorage`.
+| `LLMControls.astro`                   | Sends prompt + instructions to the backend:<br>• Optional **extra instructions** textarea.<br>• Choose from **system prompt presets** (`danbooru`, `natural-language`, future).<br>• POSTs everything to `/.netlify/functions/generatePrompt` using your `LLMConfig` settings.
 | `PromptSaver.astro`                  | Local prompt memory:<br>• Save most recent LLM output 📌<br>• View full list 📜<br>• Download all as `prompts.txt` ⬇️<br>• Clear saved prompts 🗑️<br>• Button state updates automatically based on interaction.<br>• No backend; all browser-local.                                                                                                                                                                                                                                                   |
-| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends clean prompts to **Gemma-3 via OpenUI**<br>• Auto-fallback to **Gemini 2 Flash** if Gemma fails.                                                                                                                                                       |
+| `netlify/functions/generatePrompt.js` | • Configurable `SYSTEM_PRESETS` (e.g., Danbooru / NL)<br>• **OpenAI Moderation API** with per-category probability thresholds (`BLOCK_THRESHOLDS`)<br>• Blocks only flagged categories exceeding your explicitness thresholds (e.g., allow sensitive/questionable, block explicit/minors).<br>• Sends prompts to **OpenAI** or a custom `LOCAL_LLM_URL`<br>• Auto-fallback to **Gemini 2 Flash** if primary LLM fails.                                                                                                                                                       |
 
 ---
 
@@ -108,7 +109,7 @@ Supports:
 
   * Runs **OpenAI Moderation API**
   * Checks per-category **probability scores** via `BLOCK_THRESHOLDS`
-  * Sends safe prompt to **Gemma-3 (OpenUI)** or **Gemini 2 Flash** fallback
+  * Sends safe prompt to **OpenAI** (or custom LLM) with **Gemini 2 Flash** fallback
 
 ---
 
@@ -150,16 +151,17 @@ netlify dev
 
 Set the following environment variables in `.env` or Netlify:
 
-* `OUI_API_KEY` — for Gemma 3 (OpenUI)
-* `GEMINI_API_KEY` — for Gemini fallback
-* `OPENAI_API_KEY` — for moderation scoring
+* `OPENAI_API_KEY` — for OpenAI calls and moderation (can be overridden via `LLMConfig`)
+* `LOCAL_LLM_URL`  — optional custom LLM endpoint
+* `LOCAL_LLM_KEY`  — auth token for the custom endpoint
+* `GEMINI_API_KEY` — for Gemini fallback in TerminalOverlay
 
 ---
 
 ## 🤝 Credits
 
 * Wildcard dataset: [ConquestAce/wildcards](https://huggingface.co/datasets/ConquestAce/wildcards)
-* OpenUI Gemma-3: `gemma3:1b-it-fp16`
+* OpenAI GPT models
 * Google Gemini 2 Flash fallback
 * Moderation via OpenAI `/moderations` endpoint
 

--- a/netlify/functions/generatePrompt.js
+++ b/netlify/functions/generatePrompt.js
@@ -69,8 +69,10 @@ export const handler = async (event) => {
   try { body = JSON.parse(event.body || '{}'); }
   catch { return bad('Invalid JSON payload.'); }
 
-  const { initialPrompt, preset = 'default', instructions = '' } = body;
+  const { initialPrompt, preset = 'default', instructions = '', llm = {}, geminiKey } = body;
   if (!initialPrompt?.trim()) return bad('initialPrompt missing.');
+  const config = { ...llm };
+  if (!config.geminiKey) config.geminiKey = geminiKey;
 
   /* 2 ─ content-policy gate ------------------------------------------- */
   const combinedInput = `${initialPrompt}\n\n${instructions}`;
@@ -78,8 +80,13 @@ export const handler = async (event) => {
     return bad('Prompt rejected by content policy.');
   }
 
+  const provider = config.provider || 'openai';
+
   /* 3 ─ build system prompt ------------------------------------------- */
-  const basePrompt   = SYSTEM_PRESETS[preset] ?? SYSTEM_PRESETS.default;
+  const basePrompt   =
+    (provider === 'openai' && config.systemPrompt?.trim())
+      ? config.systemPrompt.trim()
+      : SYSTEM_PRESETS[preset] ?? SYSTEM_PRESETS.default;
   const systemPrompt = instructions
     ? `${basePrompt}\n\n${instructions}`
     :  basePrompt;
@@ -89,41 +96,53 @@ export const handler = async (event) => {
     { role: 'user',   content: initialPrompt }
   ];
 
-  /* 4 ─ OpenUI (Gemma-3 primary) -------------------------------------- */
-  try {
-    const ouiRes = await fetch(
-      'https://oui.gpu.garden/api/chat/completions',
-      {
+  const model = config.model || (provider === 'gemini'
+    ? 'gemini-2.0-flash'
+    : process.env.OPENAI_MODEL || 'gpt-3.5-turbo');
+
+  if (provider !== 'gemini') {
+    /* 4 ─ OpenAI or local primary ------------------------------------ */
+    try {
+      const url = provider === 'local'
+        ? (config.localUrl || process.env.LOCAL_LLM_URL)
+        : 'https://api.openai.com/v1/chat/completions';
+      const apiKey = provider === 'local'
+        ? (config.localKey || process.env.LOCAL_LLM_KEY)
+        : (config.openaiKey || process.env.OPENAI_API_KEY);
+
+      const aiRes = await fetch(url, {
         method : 'POST',
         headers: {
-          Authorization : `Bearer ${process.env.OUI_API_KEY}`,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
         },
         body: JSON.stringify({
-          model: 'gemma3:1b-it-fp16',
+          model,
           messages,
           max_tokens: 1024
         }),
         signal: AbortSignal.timeout?.(30_000)
-      }
-    );
+      });
 
-    if (ouiRes.ok) {
-      const data = await ouiRes.json();
-      const txt  = data?.choices?.[0]?.message?.content?.trim();
-      if (txt) return ok(txt);
-    } else {
-      console.warn('[OpenUI] HTTP', ouiRes.status);
+      if (aiRes.ok) {
+        const data = await aiRes.json();
+        const txt  = data?.choices?.[0]?.message?.content?.trim();
+        if (txt) return ok(txt);
+      } else {
+        console.warn('[LLM] HTTP', aiRes.status);
+      }
+    } catch (err) {
+      console.warn('[LLM error]', err.message);
     }
-  } catch (err) {
-    console.warn('[OpenUI error]', err.message);
   }
 
-  /* 5 ─ Gemini-Flash fallback ----------------------------------------- */
+  /* 5 ─ Gemini request ----------------------------------------------- */
   try {
+    const key = config.geminiKey;
+    if (!key) return fail('Gemini key required.');
     const url =
       'https://generativelanguage.googleapis.com/v1beta/models/' +
-      'gemini-2.0-flash:generateContent?key=' + process.env.GEMINI_API_KEY;
+      `${model}:generateContent?key=` + key;
 
     const gRes = await fetch(url, {
       method : 'POST',

--- a/src/components/LLMConfig.astro
+++ b/src/components/LLMConfig.astro
@@ -1,0 +1,119 @@
+---
+/* components/LLMConfig.astro */
+---
+
+<button id="llm-open" class="bg-mathblue text-white px-3 py-1 rounded">⚙️ Configure LLM</button>
+
+<div id="llm-overlay" class="hidden fixed inset-0 z-50 bg-[#000000cc] backdrop-blur-sm flex items-center justify-center">
+  <div class="bg-slatecard p-4 rounded w-[90%] max-w-md text-lightblue space-y-4 font-mono">
+    <h2 class="text-white text-lg">LLM Configuration</h2>
+
+    <label class="block">Provider
+      <select id="llm-provider" class="bg-slatecard p-1 rounded ml-2">
+        <option value="openai">OpenAI</option>
+        <option value="gemini">Gemini</option>
+        <option value="local">Local</option>
+      </select>
+    </label>
+
+    <label class="block">Model
+      <input id="llm-model" type="text" placeholder="gpt-3.5-turbo"
+             class="bg-slatecard p-1 rounded ml-2 w-full sm:w-auto" />
+    </label>
+
+    <div id="openai-fields" class="space-y-2 hidden">
+      <label class="block">OpenAI API Key
+        <input id="openai-key" type="password" placeholder="sk-..."
+               class="bg-slatecard p-1 rounded ml-2 w-full" />
+      </label>
+      <label class="block">System Prompt
+        <textarea id="openai-system" rows="2"
+                  class="bg-slatecard p-1 rounded ml-2 w-full"></textarea>
+      </label>
+    </div>
+
+    <div id="gemini-field" class="space-y-2 hidden">
+      <label class="block">Gemini API Key
+        <input id="gemini-key" type="password" placeholder="AIza..."
+               class="bg-slatecard p-1 rounded ml-2 w-full" />
+      </label>
+    </div>
+
+    <div id="local-fields" class="space-y-2 hidden">
+      <label class="block">Endpoint URL
+        <input id="local-url" type="text" placeholder="http://127.0.0.1:8000/v1/chat/completions"
+               class="bg-slatecard p-1 rounded ml-2 w-full" />
+      </label>
+      <label class="block">Auth Key
+        <input id="local-key" type="text" class="bg-slatecard p-1 rounded ml-2 w-full" />
+      </label>
+    </div>
+
+    <div class="flex justify-end gap-2">
+      <button id="llm-save"   class="bg-green-700 text-white px-3 py-1 rounded">Save</button>
+      <button id="llm-cancel" class="bg-slategray text-white px-3 py-1 rounded">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<script is:client>
+  const openBtn    = document.getElementById('llm-open');
+  const overlay    = document.getElementById('llm-overlay');
+  const provider   = document.getElementById('llm-provider');
+  const model      = document.getElementById('llm-model');
+  const gemField   = document.getElementById('gemini-field');
+  const gemKey     = document.getElementById('gemini-key');
+  const openaiWrap = document.getElementById('openai-fields');
+  const openaiKey  = document.getElementById('openai-key');
+  const openaiSys  = document.getElementById('openai-system');
+  const localWrap  = document.getElementById('local-fields');
+  const localUrl   = document.getElementById('local-url');
+  const localKey   = document.getElementById('local-key');
+  const saveBtn    = document.getElementById('llm-save');
+  const cancelBtn  = document.getElementById('llm-cancel');
+
+  function load() {
+    const conf = JSON.parse(localStorage.getItem('llmConfig') || '{}');
+    provider.value  = conf.provider || 'openai';
+    model.value     = conf.model   || '';
+    gemKey.value    = conf.geminiKey || '';
+    openaiKey.value = conf.openaiKey || '';
+    openaiSys.value = conf.systemPrompt || '';
+    localUrl.value  = conf.localUrl || '';
+    localKey.value  = conf.localKey || '';
+    updateFields();
+  }
+
+  function updateFields() {
+    gemField.classList.toggle('hidden', provider.value !== 'gemini');
+    localWrap.classList.toggle('hidden', provider.value !== 'local');
+    openaiWrap.classList.toggle('hidden', provider.value !== 'openai');
+  }
+
+  function save() {
+    const conf = {
+      provider    : provider.value,
+      model       : model.value.trim(),
+      geminiKey   : gemKey.value.trim(),
+      openaiKey   : openaiKey.value.trim(),
+      systemPrompt: openaiSys.value.trim(),
+      localUrl    : localUrl.value.trim(),
+      localKey    : localKey.value.trim()
+    };
+    localStorage.setItem('llmConfig', JSON.stringify(conf));
+    window.dispatchEvent(new CustomEvent('llm-config-changed', { detail: conf }));
+    overlay.classList.add('hidden');
+  }
+
+  openBtn.addEventListener('click', () => {
+    load();
+    overlay.classList.remove('hidden');
+  });
+  cancelBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+  provider.addEventListener('change', updateFields);
+  saveBtn.addEventListener('click', save);
+
+  // initial config dispatch
+  load();
+  window.dispatchEvent(new CustomEvent('llm-config-changed', { detail: JSON.parse(localStorage.getItem('llmConfig') || '{}') }));
+</script>

--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -18,6 +18,7 @@
     </select>
   </label>
 
+
   <!-- send -->
   <button id="send-btn"
           class="bg-green-700 text-white px-3 py-2 rounded disabled:opacity-40"
@@ -32,17 +33,30 @@
   const notes = document.getElementById('llm-notes');
   const presetSel = document.getElementById('llmPreset');
 
+  let llmConfig = {};
+
+  function update() {
+    const needsKey = llmConfig.provider === 'gemini' && !llmConfig.geminiKey;
+    btn.disabled = !initialPrompt || needsKey;
+  }
+
   let initialPrompt = '';
 
   /* get initial prompt from PromptBuilder */
   window.addEventListener('initial-prompt', e => {
     initialPrompt = e.detail.trim();
-    btn.disabled = !initialPrompt;
+    update();
+  });
+
+  window.addEventListener('llm-config-changed', e => {
+    llmConfig = e.detail || {};
+    update();
   });
 
   /* click → POST to Netlify function */
   btn.addEventListener('click', async () => {
-    if (!initialPrompt) return;
+    const needsKey = llmConfig.provider === 'gemini' && !llmConfig.geminiKey;
+    if (!initialPrompt || needsKey) return;
     btn.disabled = true;
     post('🚀 Sending to LLM…');
 
@@ -53,7 +67,8 @@
         body   : JSON.stringify({
           initialPrompt,
           preset: presetSel.value,          // <── chosen preset
-          instructions: notes.value.trim()  // <── extra textarea
+          instructions: notes.value.trim(), // <── extra textarea
+          llm: llmConfig
         })
       });
 

--- a/src/pages/wildcarder.astro
+++ b/src/pages/wildcarder.astro
@@ -3,12 +3,16 @@ import BaseLayout     from '../layouts/BaseLayout.astro';
 import WildcardLoader from '../components/WildcardLoader.astro';
 import PromptBuilder  from '../components/PromptBuilder.astro';
 import LLMControls    from '../components/LLMControls.astro';
+import LLMConfig      from '../components/LLMConfig.astro';
 import TerminalOutput from '../components/TerminalOutput.astro';
 import PromptSaver    from '../components/PromptSaver.astro';
 ---
 
 <BaseLayout title="Wildcard Prompt Generator">
   <div class="p-6 max-w-3xl mx-auto font-mono space-y-8">
+
+    <!-- 0. configure llm -->
+    <LLMConfig />
 
     <!-- 1. defaults + drag-drop -->
     <WildcardLoader />


### PR DESCRIPTION
## Summary
- add config fields for OpenAI key and system prompt
- use custom key/prompt in serverless generator
- update README with new options

## Testing
- `npm run build` *(fails: astro not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68513413c100833088126e4cd2c6c4c7