### PR TITLE
Fix disabled LLM send button

### DIFF
--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -38,6 +38,13 @@
   let initialPrompt = '';
   let systemPrompt  = '';
 
+  /* get current system prompt immediately if available */
+  const spBox = document.getElementById('spBox');
+  if (spBox) {
+    systemPrompt = spBox.value.trim();
+  }
+  update();
+
   /* get initial prompt from PromptBuilder */
   window.addEventListener('initial-prompt', e => {
     initialPrompt = e.detail.trim();


### PR DESCRIPTION
## Summary
- initialize the current system prompt when `LLMControls` loads so the send button isn't disabled

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522b849c748330b262ba199e659cf9