### PR TITLE
Fix send button in Wildcarder

### DIFF
--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -54,6 +54,11 @@
     update();
   });
 
+  // grab existing values if events fired before hydration
+  initialPrompt = document.getElementById('prompt-box')?.value.trim() || '';
+  systemPrompt  = document.getElementById('spBox')?.value.trim() || '';
+  update();
+
   /* click → POST to Netlify function */
   btn.addEventListener('click', async () => {
     const needsKey = llmConfig.provider === 'gemini' && !llmConfig.geminiKey;


### PR DESCRIPTION
## Summary
- ensure `Send to LLM` button is enabled if initial events fire before controls hydrate

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522b849c748330b262ba199e659cf9