### PR TITLE
Fix send button initialization

### DIFF
--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -29,14 +29,22 @@
   const instrFirst = document.getElementById('instrFirst');
 
   let llmConfig = {};
+  let initialPrompt = '';
+  let systemPrompt  = '';
 
+  /* load any existing values if other components fired before us */
+  try {
+    llmConfig = JSON.parse(localStorage.getItem('llmConfig')) || {};
+  } catch {}
+  const box = document.getElementById('prompt-box');
+  if (box) initialPrompt = box.value.trim();
+  const sp = document.getElementById('spBox');
+  if (sp) systemPrompt = sp.value.trim();
+  update();
   function update() {
     const needsKey = llmConfig.provider === 'gemini' && !llmConfig.geminiKey;
     btn.disabled = !initialPrompt || !systemPrompt || needsKey;
   }
-
-  let initialPrompt = '';
-  let systemPrompt  = '';
 
   /* get initial prompt from PromptBuilder */
   window.addEventListener('initial-prompt', e => {


### PR DESCRIPTION
## Summary
- read saved LLM config and prompts when LLMControls loads
- enable Send to LLM button if pre-existing values are present

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522b849c748330b262ba199e659cf9