### PR TITLE
Fix disabled LLM send button

### DIFF
--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -38,6 +38,14 @@
   let initialPrompt = '';
   let systemPrompt  = '';
 
+  /* load existing LLM config immediately (may fire before listeners attach) */
+  try {
+    const stored = localStorage.getItem('llmConfig');
+    if (stored) {
+      llmConfig = JSON.parse(stored);
+    }
+  } catch {}
+
   /* get current prompts immediately if available */
   const spBox = document.getElementById('spBox');
   if (spBox) {

--- a/src/components/LLMControls.astro
+++ b/src/components/LLMControls.astro
@@ -38,6 +38,17 @@
   let initialPrompt = '';
   let systemPrompt  = '';
 
+  /* get current prompts immediately if available */
+  const spBox = document.getElementById('spBox');
+  if (spBox) {
+    systemPrompt = spBox.value.trim();
+  }
+  const ipBox = document.getElementById('prompt-box');
+  if (ipBox) {
+    initialPrompt = ipBox.value.trim();
+  }
+  update();
+
   /* get initial prompt from PromptBuilder */
   window.addEventListener('initial-prompt', e => {
     initialPrompt = e.detail.trim();


### PR DESCRIPTION
## Summary
- capture the initial prompt on load to enable sending once all fields are filled

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522b849c748330b262ba199e659cf9