### PR TITLE
Fix unsafe DOM usage

### DIFF
--- a/src/components/IndexTerminal.astro
+++ b/src/components/IndexTerminal.astro
@@ -52,8 +52,31 @@
     const $input = document.getElementById('inline-input');
     const $log  = document.getElementById('inline-log');
 
-    const logSys  = t => $log.innerHTML += `<div><span class="text-sky">sys</span>: ${t}</div>`;
-    const logLine = t => $log.innerHTML += `<div><span class="text-sky">conquestace@home</span>:~${pathStack.length?'/'+pathStack.join('/'):''}$ ${t}</div>`;
+    const logSys = (t) => {
+      const div = document.createElement('div');
+      const span = document.createElement('span');
+      span.className = 'text-sky';
+      span.textContent = 'sys';
+      div.appendChild(span);
+      div.append(': ');
+      div.append(document.createTextNode(t));
+      $log.appendChild(div);
+    };
+    const logSysHTML = (html) => {
+      const div = document.createElement('div');
+      div.innerHTML = `<span class="text-sky">sys</span>: ${html}`;
+      $log.appendChild(div);
+    };
+    const logLine = (t) => {
+      const div = document.createElement('div');
+      const span = document.createElement('span');
+      span.className = 'text-sky';
+      span.textContent = 'conquestace@home';
+      div.appendChild(span);
+      div.append(`:~${pathStack.length ? '/' + pathStack.join('/') : ''}$ `);
+      div.append(document.createTextNode(t));
+      $log.appendChild(div);
+    };
     const scroll  = () => $log.scrollTop = $log.scrollHeight;
 
     /* ── 3. Directory listing ── */
@@ -70,7 +93,7 @@
           ? `<a href="${entry}" target="_blank" class="terminal-file terminal-link touch" tabindex="0">${name}</a>  `
           : `<span class="terminal-folder touch" data-cd="${name}" tabindex="0">${name}/</span>  `;
       }
-      logSys(html.trim());
+      logSysHTML(html.trim());
     }
 
     /* ── 4. Navigation ── */
@@ -114,7 +137,7 @@
         window.open(dir[cmd], '_blank');
         logSys(`Opening ${cmd}…`);
       } else {
-        logSys('Unknown command or file. Try <code>ls</code>.');
+        logSysHTML('Unknown command or file. Try <code>ls</code>.');
       }
       scroll();
     });

--- a/src/components/LLMConfig.astro
+++ b/src/components/LLMConfig.astro
@@ -1,7 +1,7 @@
 ---
 /* LLMConfig.astro – provider picker + named presets (OpenAI, Gemini, Local)
    ✨ No system‑prompt editing – only provider + creds.
-   ✨ Multiple configs saved in localStorage under key `llmConfigs`.
+   ✨ Multiple configs saved in sessionStorage under key `llmConfigs`.
    ✨ Emits `llm-config-changed` whenever "Apply" is pressed. */
 ---
 
@@ -105,10 +105,10 @@ const cancelBtn  = document.getElementById('llm-cancel');
 
 /* ── Helpers ────────────────────────────── */
 function allConfigs() {
-  return JSON.parse(localStorage.getItem('llmConfigs') || '{}');
+  return JSON.parse(sessionStorage.getItem('llmConfigs') || '{}');
 }
 function saveConfigs(obj) {
-  localStorage.setItem('llmConfigs', JSON.stringify(obj));
+  sessionStorage.setItem('llmConfigs', JSON.stringify(obj));
 }
 function populateDropdown() {
   const cfgs = allConfigs();

--- a/src/components/PromptBuilder.astro
+++ b/src/components/PromptBuilder.astro
@@ -65,19 +65,26 @@
 
   /* redraw file list with drag-n-drop + count fields */
   function render() {
-    list.innerHTML = '';
+    list.textContent = '';
     files.forEach((f, idx) => {
       const li = document.createElement('li');
       li.className =
         'bg-slatecard p-2 rounded flex items-center gap-3 draggable';
       li.draggable = true;
 
-      li.innerHTML = `
-        <span class="cursor-move select-none">↕️</span>
-        <span class="flex-1 truncate">${f.name}</span>
-        <input type="number" min="1" value="${f.count}"
-               class="w-16 bg-midnight text-lightblue p-1 rounded text-right" />
-      `;
+      const move = document.createElement('span');
+      move.className = 'cursor-move select-none';
+      move.textContent = '↕️';
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'flex-1 truncate';
+      nameSpan.textContent = f.name;
+      const input = document.createElement('input');
+      input.type = 'number';
+      input.min = '1';
+      input.value = f.count;
+      input.className = 'w-16 bg-midnight text-lightblue p-1 rounded text-right';
+
+      li.append(move, nameSpan, input);
 
       /* drag & drop ordering */
       li.addEventListener('dragstart', e =>
@@ -91,7 +98,7 @@
       });
 
       /* update count */
-      li.querySelector('input').addEventListener('input', ev => {
+      input.addEventListener('input', ev => {
         f.count = Math.max(1, +ev.target.value);
       });
 

--- a/src/components/PromptSaver.astro
+++ b/src/components/PromptSaver.astro
@@ -41,10 +41,18 @@
     listEl.classList.toggle('hidden', !listOpen);
   };
 
-  const updateList = () =>
-    listEl.innerHTML = saved
-      .map((t,i)=>`<li class="mb-1"><strong>${i+1}.</strong> ${t}</li>`)
-      .join('');
+  const updateList = () => {
+    listEl.textContent = '';
+    saved.forEach((t, i) => {
+      const li = document.createElement('li');
+      li.className = 'mb-1';
+      const strong = document.createElement('strong');
+      strong.textContent = `${i + 1}.`;
+      li.appendChild(strong);
+      li.append(' ' + t);
+      listEl.appendChild(li);
+    });
+  };
 
   /* ---------- events ---------- */
   window.addEventListener('terminal-msg', e => {

--- a/src/components/TerminalOutput.astro
+++ b/src/components/TerminalOutput.astro
@@ -13,7 +13,12 @@
   const term = document.getElementById('terminal');
 
   window.addEventListener('terminal-msg', e => {
-    term.innerHTML = '<span class="text-green-400">&gt; </span>' + e.detail;
+    term.replaceChildren();
+    const prefix = document.createElement('span');
+    prefix.className = 'text-green-400';
+    prefix.textContent = '> ';
+    term.appendChild(prefix);
+    term.appendChild(document.createTextNode(e.detail));
     term.scrollTop = term.scrollHeight;
   });
 </script>

--- a/src/components/TerminalOverlay.astro
+++ b/src/components/TerminalOverlay.astro
@@ -58,15 +58,21 @@
       localStorage.removeItem(TIMESTAMP_KEY);
     }
 
+    function appendLine(role, text, logEl) {
+      const div = document.createElement('div');
+      const span = document.createElement('span');
+      span.className = 'text-sky';
+      span.textContent = role === 'user' ? 'hacker@conquestace' : 'sys';
+      div.appendChild(span);
+      div.append(role === 'user' ? ':~$ ' : ': ');
+      div.append(document.createTextNode(text));
+      logEl.appendChild(div);
+    }
+
     function renderHistory(log) {
       const history = loadHistory();
       for (const entry of history) {
-        const div = document.createElement("div");
-        const label = entry.role === "user"
-          ? '<span class="text-sky">hacker@conquestace</span>:~$ '
-          : '<span class="text-sky">sys</span>: ';
-        div.innerHTML = label + entry.text;
-        log.appendChild(div);
+        appendLine(entry.role, entry.text, log);
       }
       log.scrollTop = log.scrollHeight;
     }
@@ -102,19 +108,15 @@
 
       if (userInput.toLowerCase() === "new chat" || userInput.toLowerCase() === "reset" || userInput.toLowerCase() === "clear") {
         clearHistory();
-        log.innerHTML = "";
-        const resetMsg = document.createElement("div");
-        resetMsg.innerHTML = `<span class="text-sky">sys</span>: Chat reset. New session initialized.`;
-        log.appendChild(resetMsg);
-        saveToHistory("sys", "Chat reset. New session initialized.");
+        log.textContent = '';
+        appendLine('sys', 'Chat reset. New session initialized.', log);
+        saveToHistory('sys', 'Chat reset. New session initialized.');
         input.value = '';
         return;
       }
 
-      const userLine = document.createElement("div");
-      userLine.innerHTML = `<span class="text-sky">hacker@conquestace</span>:~$ ${userInput}`;
-      log.appendChild(userLine);
-      saveToHistory("user", userInput);
+      appendLine('user', userInput, log);
+      saveToHistory('user', userInput);
 
       input.value = '';
       log.scrollTop = log.scrollHeight;
@@ -137,17 +139,13 @@
         const data = await response.json();
         const output = data.text ?? "[no response]";
 
-        const sysLine = document.createElement("div");
-        sysLine.innerHTML = `<span class="text-sky">sys</span>: ${output}`;
-        log.appendChild(sysLine);
+        appendLine('sys', output, log);
         saveToHistory("sys", output);
 
         log.scrollTop = log.scrollHeight;
       } catch (err) {
-        const errLine = document.createElement("div");
-        errLine.innerHTML = `<span class="text-sky">sys</span>: Error: ${err.message}`;
-        log.appendChild(errLine);
-        saveToHistory("sys", `Error: ${err.message}`);
+        appendLine('sys', `Error: ${err.message}`, log);
+        saveToHistory('sys', `Error: ${err.message}`);
 
         log.scrollTop = log.scrollHeight;
       }

--- a/src/components/WildcardLoader.astro
+++ b/src/components/WildcardLoader.astro
@@ -70,16 +70,19 @@
       { detail: Object.fromEntries(store) }));
 
   const updateList = () => {
-    listEl.innerHTML = '';
+    listEl.textContent = '';
     [...store.keys()].sort().forEach(name => {
       const li = document.createElement('li');
       li.className =
         'flex items-center justify-between bg-slatecard rounded px-2 py-1';
-      li.innerHTML = `<span class="truncate">${name}</span>
-                      <button class="text-red-400">🗑️</button>`;
-      li.querySelector('button').onclick = () => {
-        store.delete(name); updateList(); dispatch();
-      };
+      const span = document.createElement('span');
+      span.className = 'truncate';
+      span.textContent = name;
+      const btn = document.createElement('button');
+      btn.className = 'text-red-400';
+      btn.textContent = '🗑️';
+      btn.onclick = () => { store.delete(name); updateList(); dispatch(); };
+      li.append(span, btn);
       listEl.appendChild(li);
     });
   };
@@ -111,7 +114,7 @@
 
   /* ───────── category pills ───────── */
   async function populateCategories() {
-    catBar.innerHTML=''; fileBar.innerHTML=''; selectedCats.clear(); selectedFiles.clear();
+    catBar.textContent=''; fileBar.textContent=''; selectedCats.clear(); selectedFiles.clear();
     const manifest = await getManifest(collSel.value);
     const cats = [...new Set(manifest.map(e=>e.category.split('/').pop()))].sort();
 
@@ -121,7 +124,7 @@
       pill.onclick = () => {
         if (selectedCats.has(cat)) {
           selectedCats.delete(cat); pill.classList.remove('active');
-          if (fileBar.dataset.cat === cat) { fileBar.innerHTML=''; selectedFiles.clear(); }
+          if (fileBar.dataset.cat === cat) { fileBar.textContent=''; selectedFiles.clear(); }
         } else {
           selectedCats.add(cat); pill.classList.add('active');
           populateFiles(cat, manifest);
@@ -133,7 +136,7 @@
 
   /* ───────── file pills ───────── */
   function populateFiles(cat, manifest) {
-    fileBar.innerHTML=''; selectedFiles.clear();
+    fileBar.textContent=''; selectedFiles.clear();
     fileBar.dataset.cat = cat;
 
     manifest.filter(e => e.category.endsWith('/'+cat))


### PR DESCRIPTION
## Summary
- sanitize terminal output updates
- sanitize saved prompt rendering
- use safe DOM methods in console overlay
- avoid innerHTML in index terminal and builder components
- replace wildcard loader innerHTML with DOM nodes
- store LLM config in sessionStorage not localStorage

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685264f724388330a376d1df815a8945