### PR TITLE
Fix serverless auth and tighten CSP

### DIFF
--- a/netlify/_headers
+++ b/netlify/_headers
@@ -9,5 +9,5 @@
     script-src  'self';
     connect-src 'self' https://api.openai.com https://generativelanguage.googleapis.com;
     img-src     'self' data:;
-    style-src   'self' 'unsafe-inline';
+    style-src   'self';
     font-src    'self' data:;

--- a/netlify/functions/_auth.js
+++ b/netlify/functions/_auth.js
@@ -1,0 +1,9 @@
+export function isAuthorized(event){
+  const secret = process.env.FUNCTION_SECRET;
+  if(!secret) return true; // no secret set -> allow
+  const header = event.headers?.authorization || event.headers?.Authorization;
+  if(!header) return false;
+  if(header === secret) return true;
+  const [type, token] = header.split(' ');
+  return type?.toLowerCase() === 'bearer' && token === secret;
+}

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -1,4 +1,9 @@
+import { isAuthorized } from "./_auth.js";
+
 export async function handler(event) {
+  if(!isAuthorized(event)) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
   try {
     const input = JSON.parse(event.body).input;
     const apiKey = process.env.GEMINI_API_KEY;

--- a/netlify/functions/generatePrompt.js
+++ b/netlify/functions/generatePrompt.js
@@ -6,6 +6,8 @@
   • All execution paths end with ok()/fail()/bad() so the client always gets JSON.
 └──────────────────────────────────────────────────────────────────────────────*/
 
+import { isAuthorized } from "./_auth.js";
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 const ok   = (t)=>({ statusCode:200, body:JSON.stringify({ text:t }) });
 const bad  = (m)=>({ statusCode:400, body:JSON.stringify({ error:m }) });
@@ -74,6 +76,8 @@ async function violatesPolicy(text){
 
 // ── Main handler ───────────────────────────────────────────────────────────
 export const handler = async(event)=>{
+  if(!isAuthorized(event))
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
   // 1) Parse payload
   let body;
   try{ body = JSON.parse(event.body||'{}'); }

--- a/netlify/functions/gpugarden.js
+++ b/netlify/functions/gpugarden.js
@@ -1,6 +1,10 @@
 import fetch from "node-fetch";
+import { isAuthorized } from "./_auth.js";
 
 export async function handler(event) {
+  if(!isAuthorized(event)) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
   try {
     const input = JSON.parse(event.body).input;
     const token = process.env.DEEPSEEK_API_KEY;

--- a/netlify/functions/llm-router.js
+++ b/netlify/functions/llm-router.js
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { isAuthorized } from "./_auth.js";
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const LOCAL_LLM_URL = process.env.LOCAL_LLM_URL;
@@ -6,6 +7,9 @@ const LOCAL_LLM_KEY = process.env.LOCAL_LLM_KEY;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 
 export async function handler(event) {
+  if(!isAuthorized(event)) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
   try {
     const { messages } = JSON.parse(event.body);
 

--- a/public/scripts/tablogic.js
+++ b/public/scripts/tablogic.js
@@ -155,7 +155,13 @@ function toggleClock() {
 
 function showMessage(user, msg) {
   const el = document.querySelector('#message');
-  if (el) el.innerHTML = `<span class="text-sky">${user}</span>: ${msg}`;
+  if (!el) return;
+  el.textContent = '';
+  const span = document.createElement('span');
+  span.className = 'text-sky';
+  span.textContent = user;
+  el.appendChild(span);
+  el.append(`: ${msg}`);
 }
 function triggerMatrix() {
   if (document.getElementById('matrix-bg')) return;


### PR DESCRIPTION
## Summary
- add a simple auth helper for Netlify functions
- secure serverless endpoints with auth check
- sanitize message rendering in `tablogic.js`
- remove unsafe-inline from CSP

## Testing
- `npm audit --omit=dev` *(fails: 403 Forbidden)*
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852798673508330a98663c8f1d09a19