### PR TITLE
Update wildcard loader UI

### DIFF
--- a/src/components/WildcardLoader.astro
+++ b/src/components/WildcardLoader.astro
@@ -14,13 +14,9 @@
   </label>
 </div>
 
-
-<!-- ───── pill bars ───── -->
-<label class="text-lightblue text-sm block mt-2">Categories:</label>
-<div id="categoryBar" class="scroll-bar"></div>
-
-<label class="text-lightblue text-sm block mt-2">Files:</label>
-<div id="fileBar" class="file-wrap"></div>
+<!-- ───── directory tree ───── -->
+<label class="text-lightblue text-sm block mt-2">Wildcards:</label>
+<div id="treeContainer" class="tree"></div>
 
 <!-- ───── drag-drop box & file list ───── -->
 <div class="space-y-3 mt-4">
@@ -53,15 +49,13 @@
   const input     = document.getElementById('fileInput');
   const listEl    = document.getElementById('fileList');
   const collSel   = document.getElementById('collectionSelector');
-  const catBar    = document.getElementById('categoryBar');
-  const fileBar   = document.getElementById('fileBar');
+  const treeEl    = document.getElementById('treeContainer');
   const loadBtn   = document.getElementById('loadDefaults');
   const clearBtn  = document.getElementById('clearWildcards');
 
   /* ───────── state ───────── */
-  const store         = new Map();          // filename → lines[]
-  const selectedCats  = new Set();          // active category ids
-  const selectedFiles = new Set();          // active file names
+  const store         = new Map();          // path → lines[]
+  const selectedPaths = new Set();          // checked file paths
   const manifestCache = {};                 // collection id → manifest[]
 
   /* ───────── utility ───────── */
@@ -112,68 +106,79 @@
     return data;
   }
 
-  /* ───────── category pills ───────── */
-  async function populateCategories() {
-    catBar.textContent=''; fileBar.textContent=''; selectedCats.clear(); selectedFiles.clear();
+  /* ───────── build tree ───────── */
+  function insert(node, parts, entry) {
+    if (parts.length === 1) {
+      node.files ??= [];
+      node.files.push({ label: parts[0], path: entry.path });
+      return;
+    }
+    const head = parts[0];
+    node.dirs ??= {};
+    node.dirs[head] ??= {};
+    insert(node.dirs[head], parts.slice(1), entry);
+  }
+
+  function render(node, parent) {
+    if (node.dirs) {
+      Object.keys(node.dirs).sort().forEach(name => {
+        const details = document.createElement('details');
+        const summary = document.createElement('summary');
+        summary.textContent = name;
+        details.appendChild(summary);
+        const ul = document.createElement('ul');
+        render(node.dirs[name], ul);
+        details.appendChild(ul);
+        parent.appendChild(details);
+      });
+    }
+    if (node.files) {
+      node.files.sort((a,b)=>a.label.localeCompare(b.label)).forEach(f => {
+        const li = document.createElement('li');
+        const label = document.createElement('label');
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.onchange = () => {
+          if (cb.checked) selectedPaths.add(f.path);
+          else selectedPaths.delete(f.path);
+        };
+        label.append(cb, document.createTextNode(' ' + f.label));
+        li.appendChild(label);
+        parent.appendChild(li);
+      });
+    }
+  }
+
+  async function populateTree() {
+    treeEl.textContent='';
+    selectedPaths.clear();
     const manifest = await getManifest(collSel.value);
-    const cats = [...new Set(manifest.map(e=>e.category.split('/').pop()))].sort();
-
-    cats.forEach(cat => {
-      const pill = document.createElement('div');
-      pill.textContent = cat; pill.className = 'pill';
-      pill.onclick = () => {
-        if (selectedCats.has(cat)) {
-          selectedCats.delete(cat); pill.classList.remove('active');
-          if (fileBar.dataset.cat === cat) { fileBar.textContent=''; selectedFiles.clear(); }
-        } else {
-          selectedCats.add(cat); pill.classList.add('active');
-          populateFiles(cat, manifest);
-        }
-      };
-      catBar.appendChild(pill);
+    const root = {};
+    manifest.forEach(e => {
+      const parts = e.path.split('/').slice(1); // skip collection id
+      insert(root, parts, e);
     });
+    const ul = document.createElement('ul');
+    render(root, ul);
+    treeEl.appendChild(ul);
   }
 
-  /* ───────── file pills ───────── */
-  function populateFiles(cat, manifest) {
-    fileBar.textContent=''; selectedFiles.clear();
-    fileBar.dataset.cat = cat;
-
-    manifest.filter(e => e.category.endsWith('/'+cat))
-            .forEach(e => {
-              const pill = document.createElement('div');
-              pill.textContent = e.name; pill.className = 'pill';
-              pill.onclick = () => {
-                if (selectedFiles.has(e.name)) {
-                  selectedFiles.delete(e.name); pill.classList.remove('active');
-                } else {
-                  selectedFiles.add(e.name); pill.classList.add('active');
-                }
-              };
-              fileBar.appendChild(pill);
-            });
-  }
-
-  collSel.addEventListener('change', populateCategories);
-  populateCategories();             // initial load
+  collSel.addEventListener('change', populateTree);
+  populateTree();             // initial load
 
   /* ───────── load defaults ───────── */
   loadBtn.onclick = async () => {
     const coll   = collSel.value;
     const manifest = await getManifest(coll);
 
-    const wantAllCats  = selectedCats.size === 0;
-    const wantAllFiles = selectedFiles.size === 0;
+    const wantAll = selectedPaths.size === 0;
 
-    for (const { name, path, category } of manifest) {
-      const catLeaf = category.split('/').pop();
-
-      if (!wantAllCats && !selectedCats.has(catLeaf)) continue;
-      if (!wantAllFiles && !selectedFiles.has(name))  continue;
-      if (store.has(name)) continue;
+    for (const { path } of manifest) {
+      if (!wantAll && !selectedPaths.has(path)) continue;
+      if (store.has(path)) continue;
 
       const txt = await fetch(HF_BASE + path).then(r=>r.text());
-      store.set(name, txt.trim().split(/\r?\n/));
+      store.set(path, txt.trim().split(/\r?\n/));
     }
     updateList(); dispatch();
   };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,3 +69,8 @@ body.matrix-mode footer {
            max-h-32 overflow-y-auto mt-1;  /* 8 rem tall before vertical scroll */
   }
   .file-wrap::-webkit-scrollbar { width: 0; height: 0; }  /* hide thin Y-scroll */
+
+  /* directory tree */
+  .tree ul { @apply pl-4 list-disc; }
+  .tree label { @apply cursor-pointer text-lightblue text-sm; }
+  .tree input[type="checkbox"] { @apply mr-1 accent-mathblue; }

--- a/website_README.md
+++ b/website_README.md
@@ -51,7 +51,7 @@ A lightweight Astro-powered tool for turning **wildcard `.txt` files** into **re
 
 | Module                                | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `WildcardLoader.astro`                | *Client-only island* for loading `.txt` wildcard files:<br>• **Drag & drop** or **browse** files manually.<br>• **Load defaults** from Hugging Face (`danbooru`, `natural-language`).<br>• **Multi-level cherry-picking**:<br>  1️⃣ **Collection selector** (top-level)<br>  2️⃣ **Category pills** (e.g., `clothing`, `styles`)<br>  3️⃣ **File pills** (wrap + multi-select)<br>• Can load **entire categories** *or* only selected files.<br>• Auto-wraps file pills to new lines.<br>• Remove files individually 🗑️ or **clear all** 🧹.<br>• Emits `wildcards-loaded` with full `{ [filename]: lines[] }` structure. |
+| `WildcardLoader.astro`                | *Client-only island* for loading `.txt` wildcard files:<br>• **Drag & drop** or **browse** files manually.<br>• **Load defaults** from Hugging Face (`danbooru`, `natural-language`).<br>• **Directory tree** with checkboxes for cherry‑picking files.<br>• Remove files individually 🗑️ or **clear all** 🧹.<br>• Emits `wildcards-loaded` with full `{ [filename]: lines[] }` structure. |
 | `PromptBuilder.astro`                 | Builds the **initial prompt** by randomly sampling lines from selected wildcards.<br>• User controls sample count per file.<br>• Supports **🔄 Re-roll**, manual editing, and live broadcasting via `initial-prompt`.                                                                                                                                                                                                                                                                                                                     |
 | `LLMConfig.astro`                     | Button to configure your LLM choice (**OpenAI**, **Gemini**, or **Local**).<br>• Lets you set model name and API keys.<br>• Saved in `sessionStorage`.
 | `LLMControls.astro`                   | Sends prompts to the backend:<br>• Uses the selected system‑prompt preset (`danbooru`, `natural-language`, custom).<br>• POSTs everything to `/.netlify/functions/generatePrompt` using your `LLMConfig` settings.
@@ -82,9 +82,8 @@ Loader pulls manifests from:
 Supports:
 
 * ✅ **Collection selection** (danbooru / natural-language)
-* ✅ **Category pills** (e.g., `clothing`, `styles`, etc.)
-* ✅ **File pills** (multi-selectable, wrapped to fit screen)
-* ✅ Loading **entire categories** or just selected files
+* ✅ **Directory tree** to pick specific files
+* ✅ Loading **entire directories** or just selected files
 
 ---
 
@@ -131,8 +130,7 @@ Supports:
 | **Add a new system-prompt preset**     | Add key in `SYSTEM_PRESETS` (Netlify function) and `<option>` in `LLMControls.astro`.                 |
 | **Adjust moderation strictness**       | Edit per-category `BLOCK_THRESHOLDS` in `generatePrompt.js`.                                          |
 | **Change sample count per file**       | Modify PromptBuilder’s sampling logic.                                                                |
-| **Tweak file/category UI styling**     | Edit Tailwind class names in `WildcardLoader.astro`.                                                  |
-| **Change file pill wrapping behavior** | Adjust CSS: use `flex-wrap` and `max-h` in `.file-wrap`.                                              |
+| **Tweak tree UI styling**              | Edit Tailwind class names in `WildcardLoader.astro` and `.tree` CSS rules.                            |
 
 ---
 


### PR DESCRIPTION
## Summary
- refactor WildcardLoader to use a directory tree with checkboxes
- add simple tree styles
- update documentation for the new tree UI

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685376fe96fc83308d76de9ff7d53fbe