### PR TITLE
Improve WildcardLoader selection UX

### DIFF
--- a/src/components/WildcardLoader.astro
+++ b/src/components/WildcardLoader.astro
@@ -6,8 +6,7 @@
      New UX philosophy
      1. Hierarchical tree (category ▸ subgroup) rendered from Hugging Face
         manifest → fewer clicks, clear context.
-     2. Check‑boxes directly add/remove files from the working set – no
-        separate “Load” step.
+     2. File names highlight when selected – no checkmark UI.
      3. Drag‑and‑drop for local wildcard text files kept (power users).
      4. Live list of everything loaded remains for quick review ✨
 ────────────────────────────────────────────────────────────────────────-->
@@ -67,6 +66,7 @@
   /* ───────── state ───────── */
   const store         = new Map();          // filename → lines[]
   const manifestCache = {};                 // collection id → manifest[]
+  let dragMode = null;                      // 'add' | 'remove' while dragging
 
   /* ───────── util helpers ───────── */
   const dispatch = () =>
@@ -86,8 +86,8 @@
       btn.textContent = '🗑️';
       btn.onclick = () => {
         store.delete(name);
-        const cb = document.querySelector(`[data-file="${name}"]`);
-        if (cb) cb.checked = false;
+        const liRef = document.querySelector(`.wildcard-item[data-file="${name}"]`);
+        if (liRef) liRef.classList.remove('bg-lightblue','text-midnight');
         updateList(); dispatch();
       };
       li.append(span, btn);
@@ -151,38 +151,50 @@
 
         files.forEach(({ name, path }) => {
           const li = document.createElement('li');
-          li.className = 'flex items-center gap-2';
+          li.className = 'wildcard-item px-2 py-1 rounded cursor-pointer select-none';
+          li.dataset.file = name;
+          li.textContent = name;
 
-          const cb = document.createElement('input');
-          cb.type  = 'checkbox';
-          cb.dataset.file = name;          // mirror back for deletion lookup
-          cb.className = 'form-checkbox h-4 w-4';
-          cb.checked = store.has(name);
+          function updateLi() {
+            if (store.has(name)) {
+              li.classList.add('bg-lightblue', 'text-midnight');
+            } else {
+              li.classList.remove('bg-lightblue', 'text-midnight');
+            }
+          }
 
-          cb.onchange = async () => {
-            if (cb.checked) {
+          async function toggle(add = !store.has(name)) {
+            if (add) {
               if (!store.has(name)) {
                 try {
                   const txt = await fetch(HF_BASE + path).then(r => r.text());
                   store.set(name, txt.trim().split(/\r?\n/));
                 } catch (err) {
                   console.error('Failed to load', name, err);
-                  cb.checked = false;
                   return;
                 }
               }
             } else {
               store.delete(name);
             }
+            updateLi();
             updateList();
             dispatch();
-          };
+          }
 
-          const label = document.createElement('label');
-          label.textContent = name;
-          label.htmlFor = cb.id;
+          li.addEventListener('click', () => toggle());
 
-          li.append(cb, label);
+          li.addEventListener('pointerdown', e => {
+            e.preventDefault();
+            dragMode = store.has(name) ? 'remove' : 'add';
+            toggle(dragMode === 'add');
+          });
+          li.addEventListener('pointerenter', () => {
+            if (!dragMode) return;
+            toggle(dragMode === 'add');
+          });
+
+          updateLi();
           ul.appendChild(li);
         });
         container.appendChild(ul);
@@ -194,6 +206,8 @@
 
   collSel.addEventListener('change', renderTree);
   renderTree();
+
+  window.addEventListener('pointerup', () => { dragMode = null; });
 
   /* ───────── drag‑and‑drop local files ───────── */
   drop.onclick = () => input.click();
@@ -216,7 +230,8 @@
   /* ───────── clear all ───────── */
   clearBtn.onclick = () => {
     store.clear();
-    document.querySelectorAll('input[type=checkbox]').forEach(cb => cb.checked = false);
+    document.querySelectorAll('.wildcard-item').forEach(li =>
+      li.classList.remove('bg-lightblue','text-midnight'));
     updateList();
     dispatch();
   };


### PR DESCRIPTION
## Summary
- highlight wildcard file names instead of using checkboxes
- support drag-selecting multiple wildcards

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538abc6f188330ad86419dbe10b8aa